### PR TITLE
Update the IRC link.

### DIFF
--- a/motion_support.html
+++ b/motion_support.html
@@ -49,7 +49,7 @@
           <li> Join the <a href="https://lists.sourceforge.net/lists/listinfo/motion-user">motion-user mailing list</a>
             and send an email including as much detail as possible with the question.  (Use the same link to unsubscribe)
           </li>
-          <li> #motion on IRC freenode</li>
+          <li> <a href="ircs://irc.libera.chat:6697/motion">#motion on Libera Chat</a> </li>
         </ul>
       <p></p>
         It is important to use these resources instead of the github issues for non-code issues since it engages a


### PR DESCRIPTION
Follow up PR to Motion-Project/motion#1398.
This was the only IRC link I found in here (and last one within the project namespace), other than on two of the former guides (4.1 and 4.1.1). For historical accuracy, I did not change those.